### PR TITLE
(maint) add support for scaling clamps down

### DIFF
--- a/lib/puppet/parser/functions/int_range.rb
+++ b/lib/puppet/parser/functions/int_range.rb
@@ -1,0 +1,7 @@
+
+module Puppet::Parser::Functions
+  newfunction(:int_range, :type => :rvalue) do |args|
+    max = args.first.to_i
+    (1..max).to_a
+  end
+end

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -6,6 +6,8 @@ define clamps::users (
   $metrics_port   = 2003,
   $daemonize      = false,
   $run_pxp        = false,
+  # TODO: use a service for daemonize so this works
+  $run_agent      = true,
   $splay          = false,
   $splaylimit     = undef,
   $use_cached_catalog = false,
@@ -148,7 +150,14 @@ define clamps::users (
       default => "/home/${user}/time-puppet-run.sh",
     }
 
+    if $run_agent {
+      $agent_ensure = present
+    } else {
+      $agent_ensure = absent
+    }
+
     cron { "cron.puppet.${user}":
+      ensure  => $agent_ensure,
       command => $cron_command,
       user    => $user,
       minute  => [ $cron_1, $cron_2 ],


### PR DESCRIPTION
I added enabled_agents so we can scale the number of agents per master back down. I updated the Puppetfile on the MoM to point to my fork but I don't know know whether to make this PR here on against puppetlabs.